### PR TITLE
load `lmodern` with `nomath`

### DIFF
--- a/ltx-talk.dtx
+++ b/ltx-talk.dtx
@@ -318,7 +318,10 @@
     \setsansfont { NewCMSans10-Regular.otf }
     \setmathfont { NewCMSansMath-Regular.otf }
   }
-  { \RequirePackage { sansmathfonts } }
+  {
+    \RequirePackage { sansmathfonts }
+    \RequirePackage [ nomath ] { lmodern }
+  }
 \cs_set_eq:NN \rmdefault \sfdefault
 %    \end{macrocode}
 %


### PR DESCRIPTION
This PR changes the used text fonts to the ones provided by `lmodern`. That way we get scalable fonts and rid of the font substitution warnings from `\frametitle` etc.