### PR TITLE
Add missing closing brace

### DIFF
--- a/ltx-talk.tex
+++ b/ltx-talk.tex
@@ -610,7 +610,7 @@ considered to be part of the before slides.
 As a possible application of the \cs{temporal} command consider the following
 example:
 \begin{verbatim}
-  \NewDocumentCommand\colorize{D<>{all}{%
+  \NewDocumentCommand\colorize{D<>{all}}{%
     \temporal<#1>{\color{red!50}}{\color{black}}{\color{black!50}}}
   \begin{frame}
     \begin{itemize}


### PR DESCRIPTION
* ltx-talk.tex (subsection{Commands with overlay specifications...}): Add missing closing brace in \colorize example.