### PR TITLE
Fix typo, ltx-tlak -> ltx-talk

### DIFF
--- a/.github/tl_packages
+++ b/.github/tl_packages
@@ -8,7 +8,7 @@ xetex
 # warnings with some packages and errors with others
 metafont
 mfware
-# Dependencies for ltx-tlak
+# Dependencies for ltx-talk
 geometry
 relsize
 # Dependencies for documentation


### PR DESCRIPTION
Found via `typos --hidden --format brief`