### PR TITLE
suppress key=value interpretation

### DIFF
--- a/ltx-talk-title.dtx
+++ b/ltx-talk-title.dtx
@@ -138,7 +138,7 @@
 % \end{macro}
 %
 % \begin{macro}{\institute, \subtitle}
-%   Simple storage at present: ubnlike some of the kernel data, there is not
+%   Simple storage at present: unlike some of the kernel data, there is not
 %   a lot to do here.
 %    \begin{macrocode}
 \NewDocumentCommand \institute { = { short-institute } O { {#2} } m }


### PR DESCRIPTION
In optional arguments using the `=`-processor that default to the contents of the mandatory argument, the user might get unexpected behaviour from the key=value processor. This PR adds an additional set of braces around the forwarded argument to suppress unwanted interpretation as key=value.