### PR TITLE
add larger math example

### DIFF
--- a/examples/math-fonts.tex
+++ b/examples/math-fonts.tex
@@ -1,0 +1,68 @@
+\DocumentMetadata{tagging = on}
+\documentclass{ltx-talk}
+
+\setmainfont{Pennstander-Regular.otf}
+\setmathfont{PennstanderMath-Regular.otf}
+
+
+\begin{document}
+
+\begin{frame}
+  \frametitle{The Quadratic Formula}
+
+  \Huge
+  \[
+    ax^2+bx+c=0
+  \]
+
+
+  
+\end{frame}
+
+
+\begin{frame}
+  \frametitle{Completing the Square}
+
+  \large
+
+  First, complete the square
+  
+  \begin{itemize}[action-spec=<+->,item-vspace=20pt,begin-vspace=20pt]
+  \item  $ax^2+bx+c=0$
+  \item  $x^2+\frac{b}{a}x+\frac{c}{a}=0$
+  \item  $x^2+\frac{b}{a}x+\bigl(\frac{b}{2a}\bigr)^2=-\frac{c}{a}+\bigl(\frac{b}{2a}\bigr)^2$
+  \item  $\bigl(x+\frac{b}{2a}\bigr)^2=-\frac{c}{a}+\bigl(\frac{b}{2a}\bigr)^2$
+  \end{itemize}
+\end{frame}
+
+\begin{frame}
+ \frametitle{Solve for $x$}
+ \large
+
+ Now, solve for $x$
+ 
+  \begin{itemize}[action-spec=<+->,item-vspace=20pt,begin-vspace=20pt]
+  \item $\bigl(x+\frac{b}{2a}\bigr)^2=-\frac{c}{a}+\bigl(\frac{b}{2a}\bigr)^2$
+  \item $x+\bigl(\frac{b}{2a}\bigr)=\pm\sqrt{-\frac{c}{a}+\bigl(\frac{b}{2a}\bigr)^2}$
+ \item $x=-\bigl(\frac{b}{2a}\bigr)\pm\sqrt{-\frac{c}{a}+\bigl(\frac{b}{2a}\bigr)^2}$
+  \item $\displaystyle x=\frac{-b\pm\sqrt{b^2-4ac}}{2a}$
+  \end{itemize}
+    
+\end{frame}
+
+\begin{frame}
+ \frametitle{The Quadratic Formula}
+ \large
+
+ The solution of the quadratic equation.
+
+ \[ax^2+bx+x=0\]
+
+ where $a$ is non zero, is given by the formula
+
+  \[x=\frac{-b\pm\sqrt{b^2-4ac}}{2a}\]
+
+    
+\end{frame}
+
+\end{document}


### PR DESCRIPTION
This PR adds a "larger"  (3 frame 10 actual pdf pages) example showing math, and also mixing both beamer-style overlay specs and enumitem-style list keys from the block template on the same environment also use of a non standard math font.

The current top level index is mostly geared to smaller "unit tests" of `ltx-talk` features. If we end up with more larger examples perhaps we will need to move things around a  bit, but I think it should be OK for now.

