### PR TITLE
fix(Contrubituing.md): Fixed one small typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 To help you focus contributions in areas that are likely to be accepted, there
 are some broad goals that are worth bearing in mind
 
-- The core aim of `ltx-talk` is to create taggd PDFs for presentations
+- The core aim of `ltx-talk` is to create tagged PDFs for presentations
 - As far as possible, `ltx-talk` is self-contained, building on functionality of
   the LaTeX kernel, including the development code in
   [`latex-lab`](https://ctan.org/pkg/latex-lab)


### PR DESCRIPTION
# Summary

Fixed "taggd" to "tagged" in Contributing.md first set of bullets under Project Goals.

## Checklist

- [x] Code follows the standard `expl3` style including no lines longer
      than 79 chars
- [?] There is a ChangeLog entry
- [x] There is a linked issue (not needed for trivial PRs, _e.g._ fixing
      typos)
- [x] `l3build ctan` passes
