### PR TITLE
'footer' -> 'header' in header description (ltx-talk.tex)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix typos in header template doc
+
 ## [v0.4.9] - 2026-04-02
 
 ### Fixed

--- a/ltx-talk.tex
+++ b/ltx-talk.tex
@@ -1400,14 +1400,14 @@ that it only applies a colored background to the footer.
 This template is used to populate the header area of the slide: this takes no
 arguments. The standard template is \texttt{talk}, which recognizes the keys
 \begin{itemize}
-  \item \opt{background-color} The color of the background of the entire footer
+  \item \opt{background-color} The color of the background of the entire header
     area
-  \item \opt{color} The color of the text in the footer area
+  \item \opt{color} The color of the text in the header area
   \item \opt{font} Font for printing elements
   \item \opt{height} The overall height of the header background area
-  \item \opt{left-hspace} Margin on left of footer
+  \item \opt{left-hspace} Margin on left of header
   \item \opt{print-frame-title} A boolean to turn title printing on and off
-  \item \opt{right-hspace} Margin on right of footer
+  \item \opt{right-hspace} Margin on right of header
 \end{itemize}
 
 Two instances of this template are pre-defined: \texttt{std} and


### PR DESCRIPTION
# Summary

Describe the change and why it is needed

Change uses of 'footer' to 'header' in description of header template in manual.
Because less incorrect.

## Checklist

- [ ] Code follows the standard `expl3` style including no lines longer
      than 79 chars N/A (no line lengths changed; no code changed)
- [x] There is a ChangeLog entry
- [ ] There is a linked issue (not needed for trivial PRs, _e.g._ fixing
      typos) N/A (trivial)
- [x] `l3build ctan` passes
