### PR TITLE
Subsec tocs (fixes #203)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Only show current subsection if toc used in subsection (see issue
+  [\#203](https://github.com/josephwright/ltx-talk/issues/203))
+
 ## [v0.4.11] - 2026-04-14
 
 ### Changed

--- a/ltx-talk-structure.dtx
+++ b/ltx-talk-structure.dtx
@@ -393,7 +393,6 @@
 %   if we are in the current section, show fully, else make semi-opaque. Needs
 %   a rounded-out interface but the basic idea will be the same.
 %    \begin{macrocode}
-\ExplSyntaxOn
 \cs_new_protected:Npn \@@_toc_dest:n
   {
     \exp_after:wN \@@_toc_dest:w \@contentsline@destination

--- a/ltx-talk-structure.dtx
+++ b/ltx-talk-structure.dtx
@@ -393,6 +393,7 @@
 %   if we are in the current section, show fully, else make semi-opaque. Needs
 %   a rounded-out interface but the basic idea will be the same.
 %    \begin{macrocode}
+\ExplSyntaxOn
 \cs_new_protected:Npn \@@_toc_dest:n
   {
     \exp_after:wN \@@_toc_dest:w \@contentsline@destination
@@ -400,7 +401,22 @@
   }
 \cs_new_protected:Npn \@@_toc_dest:w #1 . #2 . #3 . #4 . #5 \q_stop #6
   {
-    \int_compare:nNnTF { \value { section } } = {#2}
+    \bool_lazy_or:nnTF 
+      {
+        \bool_lazy_and_p:nn 
+          {
+            \int_compare_p:nNn { \value { section } } = {#2}
+          } {
+            \int_compare_p:nNn { \value { subsection } } = \c_zero_int
+          }
+      } {
+         \bool_lazy_and_p:nn 
+            {
+              \int_compare_p:nNn { \value { section } } = {#2}
+            } {
+              \int_compare_p:nNn { \value { subsection } } = {#3}
+            }
+      }
       {#6}
       {
         \opacity_begin:n { 0.2 }


### PR DESCRIPTION
# Summary

Describe the change and why it is needed

Change `\tableofcontents` to only highlight current subsection, if used inside a subsection.
This prevents duplicate slides if contents are produced for subsections as well as sections.

## Checklist

- [X] Code follows the standard `expl3` style including no lines longer
      than 79 chars
- [X] There is a ChangeLog entry
- [X] There is a linked issue (not needed for trivial PRs, _e.g._ fixing
      typos)
- [x] `l3build ctan` passes

Fixes (sort of) #203 
