### PR TITLE
Fix declaration of an internal var

### DIFF
--- a/ltx-talk.dtx
+++ b/ltx-talk.dtx
@@ -181,7 +181,7 @@
 %
 % \begin{variable}{\l_@@_tmp_clist}
 %    \begin{macrocode}
-\tl_new:N \l_@@_tmp_clist
+\clist_new:N \l_@@_tmp_clist
 %    \end{macrocode}
 % \end{variable}
 %


### PR DESCRIPTION
# Summary

`\l_@@_tmp_clist` was declared by `\tl_new:N`.

Is a Changelog entry needed?

## Checklist

- [x] Code follows the standard `expl3` style including no lines longer
      than 79 chars
- [ ] There is a ChangeLog entry
- [ ] There is a linked issue (not needed for trivial PRs, _e.g._ fixing
      typos)
- [ ] `l3build ctan` passes
