### PR TITLE
Replace deprecated `\l_keys_choice_tl` with corresp. `str` var

### DIFF
--- a/ltx-talk.dtx
+++ b/ltx-talk.dtx
@@ -215,10 +215,10 @@
     handout .value_forbidden:n = true ,
     mode .choices:nn =
       { handout , projector }
-      { \str_set_eq:NN \l_@@_mode_str \l_keys_choice_tl } ,
+      { \str_set_eq:NN \l_@@_mode_str \l_keys_choice_str } ,
     supplementary-frames .choices:nn =
       { appendix , in-place , omit }
-      { \str_set_eq:NN \l_@@_suppl_mode_str \l_keys_choice_tl }
+      { \str_set_eq:NN \l_@@_suppl_mode_str \l_keys_choice_str }
   }
 \str_new:N \l_@@_mode_str
 \str_new:N \l_@@_suppl_mode_str


### PR DESCRIPTION
# Summary

As per the title.

`\l_keys_choice_tl` was replaced by `\l_keys_choice_str` in [l3kernel 2025-10-09](https://github.com/latex3/latex3/blob/develop/l3kernel/CHANGELOG.md#2025-10-09), but ltx-talk already requires LaTeX2e 2026-06-01.

## Checklist

- [x] Code follows the standard `expl3` style including no lines longer
      than 79 chars
- [ ] There is a ChangeLog entry
- [ ] There is a linked issue (not needed for trivial PRs, _e.g._ fixing
      typos)
- [ ] `l3build ctan` passes
